### PR TITLE
Update travis configuration for repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,16 @@
 language: ruby
+cache: bundler
+
 rvm:
   - 2.2.3
+
 before_install: gem install bundler -v 1.11.2
+
+# Have this option to stop travis-ci building twice. Currently we have travis set to build both
+# PR's and pushes. However this means when we push to a PR we have to wait for Travis to finish
+# 2 builds. If we unticked 'pushes' when the PR was finally merged that would not be built. The
+# brute force approach would be to untick build PR's and just build all pushes. We instead have
+# gone with the approach outlined here http://stackoverflow.com/a/31882307
+branches:
+  only:
+    - master

--- a/README.md
+++ b/README.md
@@ -1,25 +1,29 @@
 # EA::AreaLookup
 
+[![Build Status](https://travis-ci.org/EnvironmentAgency/ea-area_lookup.svg?branch=master)](https://travis-ci.org/EnvironmentAgency/ea-area_lookup)
+
 This ruby gem provides a means of looking up the Environnment Agency Administrative Area (e.g. 'Wessex')
 for a given easting and northing. It wraps an API designed for this purpose.
 
 ## Installation
 
-Add this line to your application's Gemfile:
+Add this line to your application's Gemfile
 
 ```ruby
 gem 'ea-area_lookup'
 ```
 
-And then execute:
+And then update your dependencies by calling
 
-    $ bundle
+```bash
+bundle install
+```
 
 ## Usage
 
 ### Rails
 
-Create an intializer eg ```config/initializers/area_lookup.rb```
+Create an intializer e.g. `config/initializers/area_lookup.rb`
 
 ```ruby
 EA::AreaLookup.configure do |config|
@@ -27,7 +31,7 @@ EA::AreaLookup.configure do |config|
 end
 ```
 
-Now you can do the following:
+Now you can do the following
 
 ```ruby
 coords = EA::AreaLookup::Coordinates.new(easting: 123, northing: 456)
@@ -42,8 +46,7 @@ Note that the `Coordinates` class accepts x and y synonymously with easting and 
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies.
-Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt
-that will allow you to experiment.
+Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 ## Contributing to this project
 


### PR DESCRIPTION
This change makes the following changes to our Travis-CI configuration
- Stops travis building twice for a particular commit
- Cache's dependencies between build
- Adds the travis build badge to the README
