### PR TITLE
Remove before_commit from project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 /tmp/
 .DS_Store
 .byebug_history
+.rspec-local

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,1 @@
---format documentation
 --color

--- a/Rakefile
+++ b/Rakefile
@@ -4,8 +4,3 @@ require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec
-
-# Add the before_commit rake task
-require "before_commit"
-spec = Gem::Specification.find_by_name "before_commit"
-load "#{spec.gem_dir}/lib/tasks/before_commit.rake"

--- a/ea-area_lookup.gemspec
+++ b/ea-area_lookup.gemspec
@@ -27,9 +27,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "byebug"
-  spec.add_development_dependency  "vcr", "~> 3.0"
-  spec.add_development_dependency  "webmock", "~> 1.24"
-  spec.add_development_dependency  "shoulda-matchers", "~> 3.1"
-  spec.add_development_dependency  "simplecov"
-  spec.add_development_dependency  "before_commit"
+  spec.add_development_dependency "vcr", "~> 3.0"
+  spec.add_development_dependency "webmock", "~> 1.24"
+  spec.add_development_dependency "shoulda-matchers", "~> 3.1"
+  spec.add_development_dependency "simplecov"
 end


### PR DESCRIPTION
We use [before_commit](https://github.com/EnvironmentAgency/before_commit) to help ensure the consistency and quality of the code we are checking in on the projects maintained by the Digital Service Team (south).

However as long as contributions meet these requirements we currently don't require contributors to also use this tool. This change removes the dependency and associated files from the project.
