### PR TITLE
Setup codeclimate test coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,6 @@ ruby "2.2.3"
 
 # Specify your gem's dependencies in gemspec
 gemspec
+
+# Required to enable codeclimate's test coverage functionality
+gem "codeclimate-test-reporter", group: :test, require: nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require "codeclimate-test-reporter"
 require "simplecov"
 require "byebug"
 require "vcr"


### PR DESCRIPTION
This change configures the repo to work with codeclimates test coverage functionality.

To do this we need to add a gem and require it in the spec_helper.
