### PR TITLE
Add codeclimate config file

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,22 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - ruby
+      - javascript
+  fixme:
+    enabled: true
+  rubocop:
+    enabled: true
+  brakeman:
+    enabled: true
+  rubymotion:
+    enabled: true
+ratings:
+  paths:
+  - "**.module"
+  - "**.rb"
+exclude_paths:
+- spec/


### PR DESCRIPTION
This change adds the default generated codeclimate config file. This is part of our efforts to capture metrics about the project using codeclimate.
