### PR TITLE
Link Travis CI build to codeclimate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,12 @@ before_install: gem install bundler -v 1.11.2
 branches:
   only:
     - master
+
+# This section was added as per https://docs.travis-ci.com/user/code-climate/
+# To protect our codeclimate stats rather than adding the Codeclimate API key for ea-area_lookup
+# in the open we used this guide https://docs.travis-ci.com/user/encryption-keys/ to encryt the
+# value. Essentially install travis gem, then run `travis encrypt <my_code_climate_api_key>`
+addons:
+  code_climate:
+    repo_token:
+      secure: "DsWI1kzx5RIfB/QQysErQTW94FF6v512q3vqFChSXaAViJA6LgU9coBRiLtZ3RyE0YcvPzu0B1q/fqR4sDq4xG1L6VMY2PlF4ZI57AaPa1WFmzT9mCAhYCbpYKXuMySCoS4YvoHrHgwd30M0RYmiRtZY75Olmbd1PsbbZGfnIGwcEchujHb6oQ6WKgEAqq6zvHHf5QM18oSm4ZCFSYijGU7BvxMsLTToFuPnndGomWHCfMDSyBkC2wt5pmfdsjbirrsPPnFbYxCOCxGk77WWw9G+swUZclgUiUn1q2tSFgri27zufbFuGknDWf9HMiMqzgfCO8kut/78CqRjt5BtUm2otJLEhlpmL4t9rqDUKl/hmc+asxfoj04qP1cNRmjZf0QYbT4rFlsFlcNgYNcZcLf66ry9c8WXcpV6qvKukaT9Xyj1/KAVXDqO1EUd1oEBIoKnILW7H4Zhbjhu6lq2ga47Wux0IrMdtHE2RwjdtCxwfhkuUcblfnPpjW8tXeDND0nE/Se45rXZ/YwojZSeqyZCvZbcXMOvggzRQeAgi02sruw33oZU6W/f8VOjC5VrB1KEHm4j0n21dI6ENu0D+tbjBIW0TvI47hAuV/R1v7kHJVbSIcAedtxWt87mSdyQkOukCVSYHMOKJHY6T1EtZlK5V9RHDrHD8KIMeJV/Dx0="

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,12 +8,18 @@ $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "ea/area_lookup"
 
 # Stubexternal services = see https://github.com/vcr/vcr
-VCR.configure do |c|
-  c.cassette_library_dir = "spec/cassettes"
-  c.hook_into :webmock
-  c.ignore_hosts "127.0.0.1"
-  c.allow_http_connections_when_no_cassette = false
-  c.default_cassette_options = {
+VCR.configure do |config|
+  # As per codeclimate "VCR [..] will prevent the codeclimate-test-reporter from
+  # reporting results to codeclimate.com" Recieved this error when first
+  # configuring integration to codeclimate and the fix is to add it to
+  # ignore_hosts.
+  config.ignore_hosts 'codeclimate.com'
+
+  config.cassette_library_dir = "spec/cassettes"
+  config.hook_into :webmock
+  config.ignore_hosts "127.0.0.1"
+  config.allow_http_connections_when_no_cassette = false
+  config.default_cassette_options = {
     record: :once
   }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require "codeclimate-test-reporter"
+CodeClimate::TestReporter.start
 require "simplecov"
 require "byebug"
 require "vcr"


### PR DESCRIPTION
We have previously added the gem from codeclimate which generates code coverage stats, and we have added the codeclimate configuration file. However to get test coverage reported we need to pass the stats to codeclimate somehow.

This changes updates the .travis.yml to tell it to forward these stats after a build to codeclimate, and authenticates by using an ecrypted API also included in the file.
