### PR TITLE
Fix brakeman issue in .codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -11,7 +11,7 @@ engines:
   rubocop:
     enabled: true
   brakeman:
-    enabled: true
+    enabled: false
   rubymotion:
     enabled: true
 ratings:


### PR DESCRIPTION
We had brakeman enabled however this is not a rails app so it just generates an error in codeclimate. This change disables brakeman in the config file.
