### PR TITLE
Add RSpec mock helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ And then update your dependencies by calling
 bundle install
 ```
 
+
 ## Usage
 
 ### Rails
@@ -45,6 +46,45 @@ p result
 ```
 
 Note that the `Coordinates` class accepts x and y synonymously with easting and northing.
+
+## Testing with RSpec
+A test helper is included that provides methods that will stub calls to
+EA::AreaLookup methods in RSpec tests.
+
+The available mock methods are:
+
+```
+mock_ea_area_lookup_find_by_coordinates
+mock_no_results_ea_area_lookup_find_by_coordinates
+mock_failure_of_ea_area_lookup_find_by_coordinates
+```
+
+To enable them add this to the rspec configuration (for example, within a
+ `RSpec.configure do |config|` block in a Rails app's `spec/rails_helper.rb`):
+
+```ruby
+config.include EA::AreaLookup::TestHelper::RspecMocks
+```
+
+This will make the methods defined in `lib/ea/area_lookup/test_helper/rspec_mocks.rb`
+available within the host app's rspec tests. For example:
+
+```ruby
+describe "postcode lookup" do
+  before do
+    mock_ea_area_lookup_find_by_coordinates
+  end
+
+  it "some tests that use data returned by a coordinate lokup" do
+    ....
+    # Any EA::AreaLookup.find_by_coordinates calls made in this spec will return the same
+    # mocked data, and no external requests will be made, so you don't need webmock/VCR.
+    # You can pass any coord aruments and they will
+    # always return the mocked data and will not echo back your input.
+    # See test_helper/area_lookup.yml to examine the mock data that will be returned.
+  end
+end
+```
 
 ## Development
 

--- a/lib/ea/area_lookup.rb
+++ b/lib/ea/area_lookup.rb
@@ -4,6 +4,7 @@ require "ea/area_lookup/errors"
 require "ea/area_lookup/logger"
 require "ea/area_lookup/coordinates"
 require "ea/area_lookup/finders"
+require "ea/area_lookup/test_helper/rspec_mocks"
 
 module EA
   module AreaLookup

--- a/lib/ea/area_lookup/test_helper/area_lookup.yml
+++ b/lib/ea/area_lookup/test_helper/area_lookup.yml
@@ -1,0 +1,14 @@
+---
+find_by_coordinates:
+  :area_id: '28.000000000000000'
+  :code: WESSEX
+  :area_name: Wessex
+  :short_name: Wessex
+  :long_name: Wessex"
+
+find_by_coordinates_not_found:
+  :area_id: ''
+  :code: ''
+  :area_name: ''
+  :short_name: ''
+  :long_name: ''

--- a/lib/ea/area_lookup/test_helper/mock_data.rb
+++ b/lib/ea/area_lookup/test_helper/mock_data.rb
@@ -1,0 +1,32 @@
+module EA
+  module AreaLookup
+    module TestHelper
+      class MockData
+
+        def initialize(file_name)
+          @file_name = file_name.to_s.strip
+        end
+
+        def data_for(key)
+          yaml[key.to_s]
+        end
+
+        private
+
+        def file_name
+          return @file_name if @file_name =~ /\.yml$/
+          "#{@file_name}.yml"
+        end
+
+        def path
+          File.expand_path file_name, File.dirname(__FILE__)
+        end
+
+        def yaml
+          @yaml ||= YAML.load_file path
+        end
+
+      end
+    end
+  end
+end

--- a/lib/ea/area_lookup/test_helper/rspec_mocks.rb
+++ b/lib/ea/area_lookup/test_helper/rspec_mocks.rb
@@ -1,0 +1,35 @@
+require_relative "mock_data"
+module EA
+  module AreaLookup
+    module TestHelper
+      # Uses data from area_lookup.yml to mock calls to EA::AreaLookup methods
+      module RspecMocks
+
+        def mock_ea_area_lookup_find_by_coordinates
+          allow(EA::AreaLookup)
+            .to receive(:find_by_coordinates)
+            .and_return(mock_data.data_for(:find_by_coordinates))
+        end
+
+        def mock_no_results_ea_area_lookup_find_by_coordinates
+          allow(EA::AddressLookup)
+            .to receive(:find_by_coordinates)
+            .and_return(mock_data.data_for(:find_by_coordinates_not_found))
+        end
+
+        def mock_failure_of_ea_area_lookup_find_by_coordinates
+          allow(EA::AddressLookup)
+            .to receive(:find_by_coordinates)
+            .and_raise(EA::AreaLookup::ApiConnectionError, "Whoops")
+        end
+
+        private
+
+        def mock_data
+          @mock_data ||= MockData.new :address_lookup
+        end
+
+      end
+    end
+  end
+end

--- a/lib/ea/area_lookup/version.rb
+++ b/lib/ea/area_lookup/version.rb
@@ -1,5 +1,5 @@
 module EA
   module AreaLookup
-    VERSION = "0.1.1".freeze
+    VERSION = "0.1.2".freeze
   end
 end

--- a/spec/ea/area_lookup/test_helper/mock_data_spec.rb
+++ b/spec/ea/area_lookup/test_helper/mock_data_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+module EA
+  module AreaLookup
+    module TestHelper
+      describe MockData do
+        let(:mock_data) { described_class.new(:area_lookup) }
+        let(:api_url)   { "http://www.geostore.com/OGC/OGCInterface" }
+
+        describe "#data_for" do
+          context "with :find_by_coordinates" do
+            let(:data) { mock_data.data_for :find_by_coordinates }
+
+            it "mock data should match the keys in the real http response - "\
+               "this catches the scenario where the underlying API has changed but "\
+               "the mock data has not been updated to reflect this" do
+              EA::AreaLookup.config.administrative_area_api_url = api_url
+              coords = EA::AreaLookup::Coordinates.new(easting: 358_205.03, northing: 172_708.07)
+              response = VCR.use_cassette("area_found") do
+                EA::AreaLookup.find_by_coordinates(coords)
+              end
+              data = mock_data.data_for(:find_by_coordinates)
+
+              expect(data.keys.sort).to eq(response.keys.sort)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
These aid testing in consuming apps - they can mock
area lookup calls using the supplied methods to prevent
network calls being made, and without having to use VCR/webmock.
