### PR TITLE
Integrate project with Hakiri

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # EA::AreaLookup
 
 [![Build Status](https://travis-ci.org/EnvironmentAgency/ea-area_lookup.svg?branch=master)](https://travis-ci.org/EnvironmentAgency/ea-area_lookup)
+[![security](https://hakiri.io/github/EnvironmentAgency/ea-area_lookup/master.svg)](https://hakiri.io/github/EnvironmentAgency/ea-area_lookup/master)
 [![Code Climate](https://codeclimate.com/github/EnvironmentAgency/ea-area_lookup/badges/gpa.svg)](https://codeclimate.com/github/EnvironmentAgency/ea-area_lookup)
 [![Test Coverage](https://codeclimate.com/github/EnvironmentAgency/ea-area_lookup/badges/coverage.svg)](https://codeclimate.com/github/EnvironmentAgency/ea-area_lookup/coverage)
 [![Gem Version](https://badge.fury.io/rb/ea-area_lookup.svg)](https://badge.fury.io/rb/ea-area_lookup)

--- a/ea-area_lookup.gemspec
+++ b/ea-area_lookup.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "nokogiri", "~> 1.3"
+  spec.add_dependency "nokogiri", "~> 1.6.8"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
[Hakiri](https://hakiri.io) is an online security tool which scans the dependencies of a project for known vulnerabilities. We have committed to adding it to all our open source projects, as its simple to do and increases security of the code and services that use it.
