### PR TITLE
Add a default administrative_area_url

### DIFF
--- a/lib/ea/area_lookup/configuration.rb
+++ b/lib/ea/area_lookup/configuration.rb
@@ -2,6 +2,10 @@ module EA
   module AreaLookup
     class Configuration
       attr_accessor :administrative_area_api_url
+
+      def initialize
+        @administrative_area_api_url ||= "http://environment.data.gov.uk/ds/wfs"
+      end
     end
 
     def self.config

--- a/lib/ea/area_lookup/version.rb
+++ b/lib/ea/area_lookup/version.rb
@@ -1,5 +1,5 @@
 module EA
   module AreaLookup
-    VERSION = "0.1.1".freeze
+    VERSION = "0.1.2".freeze
   end
 end

--- a/spec/ea/area_lookup/configuration_spec.rb
+++ b/spec/ea/area_lookup/configuration_spec.rb
@@ -14,8 +14,9 @@ describe EA::AreaLookup::Configuration do
   describe "#reset" do
     it "clears down previously set configuration" do
       EA::AreaLookup.configure { |c| c.administrative_area_api_url = "a" }
+      expect(EA::AreaLookup.config.administrative_area_api_url).to eq("a")
       EA::AreaLookup.reset
-      expect(EA::AreaLookup.config.administrative_area_api_url).to be_nil
+      expect(EA::AreaLookup.config.administrative_area_api_url).to_not eq("a")
     end
   end
 end


### PR DESCRIPTION
Add a default url point to http://environment.data.gov.uk
