### PR TITLE
Archive project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # EA::AreaLookup
 
-[![Build Status](https://travis-ci.org/DEFRA/ea-area_lookup.svg?branch=master)](https://travis-ci.org/DEFRA/ea-area_lookup)
-[![security](https://hakiri.io/github/DEFRA/ea-area_lookup/master.svg)](https://hakiri.io/github/DEFRA/ea-area_lookup/master)
-[![Code Climate](https://codeclimate.com/github/DEFRA/ea-area_lookup/badges/gpa.svg)](https://codeclimate.com/github/DEFRA/ea-area_lookup)
-[![Test Coverage](https://codeclimate.com/github/DEFRA/ea-area_lookup/badges/coverage.svg)](https://codeclimate.com/github/DEFRA/ea-area_lookup/coverage)
-[![Gem Version](https://badge.fury.io/rb/ea-area_lookup.svg)](https://badge.fury.io/rb/ea-area_lookup)
+> This project is no longer maintained and has been replaced by [defra_ruby_area](https://github.com/DEFRA/defra-ruby-area)
 
 This ruby gem provides a means of looking up the Environment Agency Administrative Area (e.g. 'Wessex')
 for a given easting and northing. It wraps an API designed for this purpose.

--- a/ea-area_lookup.gemspec
+++ b/ea-area_lookup.gemspec
@@ -6,14 +6,20 @@ require "ea/area_lookup/version"
 Gem::Specification.new do |spec|
   spec.name          = "ea-area_lookup"
   spec.version       = EA::AreaLookup::VERSION
-  spec.authors       = ["Digital Services Team, EnvironmentAgency"]
-  spec.email         = ["dst@environment-agency.gov.uk"]
+  spec.authors       = ["Defra"]
+  spec.email         = ["alan.cruikshanks@environment-agency.gov.uk"]
 
-  spec.summary       = "Provides a means of looking-up Environment Agency administrative areas."
-  spec.description   = "Provides a means of looking-up an Environment Agency administrative area "\
-                       "using the co-ordinates of any point in England."
-  spec.homepage      = "https://github.com/EnvironmentAgency"
+  spec.summary       = "No longer maintained. Search for defra_ruby_area instead"
+  spec.description   = "No longer maintained. Use defra_ruby_area instead "\
+                       "(https://github.com/DEFRA/defra-ruby-area)"
+  spec.homepage      = "https://github.com/DEFRA"
   spec.license       = "The Open Government Licence (OGL) Version 3"
+
+  s.post_install_message = %q(
+  This gem is no longer maintained.
+  Please use http://github.com/DEFRA/defra-ruby-area instead
+
+  )
 
   spec.required_ruby_version = ">= 2.2"
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }

--- a/lib/ea/area_lookup/version.rb
+++ b/lib/ea/area_lookup/version.rb
@@ -1,5 +1,5 @@
 module EA
   module AreaLookup
-    VERSION = "0.2.2".freeze
+    VERSION = "0.2.3".freeze
   end
 end


### PR DESCRIPTION
These updates put the project into an archived state. This gem has been replaced by [defra_ruby_area](https://github.com/DEFRA/defra-ruby-area) as both the naming and structure of the new gem more closely follow our current conventions.

**ea-area_lookup** has been replaced in the one project it was used, so as far as the [ruby services team](https://github.com/DEFRA/ruby-services-team) are concerned, we have no reason to go on maintaining it.